### PR TITLE
Fix a typo of the program name in file headers

### DIFF
--- a/actinia/__init__.py
+++ b/actinia/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/actinia/actinia.py
+++ b/actinia/actinia.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/actinia/job.py
+++ b/actinia/job.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/actinia/location.py
+++ b/actinia/location.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/actinia/mapset.py
+++ b/actinia/mapset.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/actinia/region.py
+++ b/actinia/region.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/actinia/strds.py
+++ b/actinia/strds.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/actinia/vector.py
+++ b/actinia/vector.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/mock/__init__.py
+++ b/tests/mock/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/mock/actinia_location_management_mock.py
+++ b/tests/mock/actinia_location_management_mock.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/mock/actinia_mock.py
+++ b/tests/mock/actinia_mock.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/mock/actinia_process_chain_validation_mock.py
+++ b/tests/mock/actinia_process_chain_validation_mock.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/test_actinia_base.py
+++ b/tests/test_actinia_base.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/test_actinia_location_management.py
+++ b/tests/test_actinia_location_management.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/test_actinia_mapset_management.py
+++ b/tests/test_actinia_mapset_management.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/test_actinia_processing.py
+++ b/tests/test_actinia_processing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #

--- a/tests/test_process_chain_validation.py
+++ b/tests/test_process_chain_validation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #######
-# acintia-python-client is a python client for actinia - an open source REST
+# actinia-python-client is a python client for actinia - an open source REST
 # API for scalable, distributed, high performance processing of geographical
 # data that uses GRASS GIS for computational tasks.
 #


### PR DESCRIPTION
This fixes occurrences of `acintia` to the correct spelling `actinia` :-)

Please review.